### PR TITLE
Don't create ignore entry for patch upgrade strategies

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,7 @@ fn main() -> anyhow::Result<()> {
                     UpdateStrategy::Minor => {
                         vec![UpdateType::SemverPatch]
                     }
-                    UpdateStrategy::Patch => vec![],
+                    UpdateStrategy::Patch => return None,
                 };
                 let mut ignore = Ignore::new(name.clone());
                 ignore.update_types = Some(update_types);


### PR DESCRIPTION
Dependabot gets upset if the update-types field is an empty array. So stop creating ignore entries crates with only a patch version